### PR TITLE
Apply patch for allowing MD5 usage

### DIFF
--- a/easy_thumbnails/utils.py
+++ b/easy_thumbnails/utils.py
@@ -76,7 +76,7 @@ def get_storage_hash(storage):
     if not isinstance(storage, str):
         storage_cls = storage.__class__
         storage = '%s.%s' % (storage_cls.__module__, storage_cls.__name__)
-    return hashlib.md5(storage.encode('utf8')).hexdigest()
+    return hashlib.md5(storage.encode('utf8'), usedforsecurity=False).hexdigest()
 
 
 def is_transparent(image):

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ def read_files(*filenames):
 
 setup(
     name='easy-thumbnails',
-    version=easy_thumbnails.get_version(),
+    version="{0}+nimbis.1".format(easy_thumbnails.get_version()),
     url='http://github.com/SmileyChris/easy-thumbnails',
     description='Easy thumbnails for Django',
     long_description=read_files('README.rst', 'CHANGES.rst'),


### PR DESCRIPTION
This applies a patch to allow the use of Django on a FIPS-compliant
system with MD5 disabled. This utilizes the optional
'usedforsecurity=False' parameter that is passed into the hashlib.md5
function. This allows the use of MD5 even when MD5 has been disabled at
the system level.