### PR TITLE
Add try-except around hashlib.md5 calls passing usedforsecurity=False

### DIFF
--- a/easy_thumbnails/utils.py
+++ b/easy_thumbnails/utils.py
@@ -76,7 +76,17 @@ def get_storage_hash(storage):
     if not isinstance(storage, str):
         storage_cls = storage.__class__
         storage = '%s.%s' % (storage_cls.__module__, storage_cls.__name__)
-    return hashlib.md5(storage.encode('utf8'), usedforsecurity=False).hexdigest()
+
+    # Current stable version of python does not have FIPS support for hashlib. Passing
+    # usedforsecurity=False only works in RHEL versions of python, and is needed to
+    # run this code on hardened RHEL machines. The try-except block will not be needed once
+    # the following issue is resolved:
+    #
+    # https://bugs.python.org/issue9216
+    try:
+        return hashlib.md5(storage.encode('utf8'), usedforsecurity=False).hexdigest()
+    except TypeError:
+        return hashlib.md5(storage.encode('utf8')).hexdigest()
 
 
 def is_transparent(image):

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ def read_files(*filenames):
 
 setup(
     name='easy-thumbnails',
-    version="{0}+nimbis.1".format(easy_thumbnails.get_version()),
+    version="{0}+nimbis.2".format(easy_thumbnails.get_version()),
     url='http://github.com/SmileyChris/easy-thumbnails',
     description='Easy thumbnails for Django',
     long_description=read_files('README.rst', 'CHANGES.rst'),


### PR DESCRIPTION
An exception is currently thrown if passing the usedforsecurity=False
flag when calling hashlib.md5 using a version of python that currently
does not support FIPS.

At the time of this commit, the RHEL version of python supported
this, however, other versions did not. This issue is captured here:
https://bugs.python.org/issue9216

These changes can be dropped once that issue is resolved.